### PR TITLE
YAML files are not parsed anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "illuminate/contracts": "~5.0",
         "illuminate/console": "~5.0",
         "illuminate/filesystem": "~5.0",
-        "symfony/yaml": ">=2.6"
+        "symfony/yaml": ">=2.6,<3.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1",


### PR DESCRIPTION
Added a constraint on the composer.json file for symfony/yaml.

Change from symfony/yaml: https://github.com/symfony/yaml/blob/3.0/Yaml.php vs https://github.com/symfony/yaml/blob/2.8/Yaml.php
